### PR TITLE
Add Midnight to Blockchains with private smart contracts

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ This is a combination of papers and articles that cover various aspects of block
 - [ZkVM](https://github.com/stellar/slingshot/blob/main/zkvm/README.md)
 - [Ekiden](https://arxiv.org/abs/1804.05141)
 - [DarkFi](https://github.com/darkrenaissance/darkfi)
+- [Midnight](https://midnight.network/) (based on the [Kachina](https://eprint.iacr.org/2020/543) protocol)
 
 ### Using Zk-Snarks
 - [Zerocash](http://zerocash-project.org/media/pdf/zerocash-extended-20140518.pdf)


### PR DESCRIPTION
Adds Midnight to the "Blockchains with private smart contracts" subsection under Alternate Blockchain designs.

Midnight is a privacy-enhancing blockchain that launched mainnet on March 30th, 2026. It implements the Kachina protocol (Kerber, Kiayias, Kohlweiss, CSF 2021), which provides a unified security model for private smart contracts based on the Universal Composition framework.

Note: Ouroboros Crypsinous (Kerber, Kiayias, Kohlweiss, Zikas) is already listed under Privacy-Preserving PoS Protocols. Kachina is the companion protocol from the same research group covering the smart contract layer, so Midnight's inclusion here complements existing content rather than duplicating it.

On CONTRIBUTING.md: I noticed the alphabetization rule and also that the existing entries in this subsection aren't currently in alphabetical order. I added Midnight at the bottom to match the existing insertion-order convention rather than scope-creep this PR into a reordering.